### PR TITLE
Refactor error handling in buildInputCoin to use AggregatorError

### DIFF
--- a/src/utils/coin.ts
+++ b/src/utils/coin.ts
@@ -1,6 +1,6 @@
 import { CoinAsset } from "../types/sui"
 import { CoinUtils } from "../types/CoinAssist"
-import { TransactionErrorCode } from "../errors"
+import { AggregatorError, TransactionErrorCode } from "../errors"
 import {
   Transaction,
   TransactionObjectArgument,
@@ -75,9 +75,9 @@ export function buildInputCoin(
 
   let totalCoinBalance = CoinUtils.calculateTotalBalance(usedCoinAsests)
   if (totalCoinBalance < amount) {
-    throw new AggregateError(
+    throw new AggregatorError(
       "Insufficient balance when build merge coin, coinType: " + coinType,
-      TransactionErrorCode.InsufficientBalance  + coinType
+      TransactionErrorCode.InsufficientBalance
     )
   }
 


### PR DESCRIPTION
This change probably fixes the following issue;

```
AggregateError: InsufficientBalance0xdeeb7a4662eec9f2f3def03fb937a663dddaa2e215b8078a284d026b7946c270::deep::DEEP
    at buildInputCoin (file:///home/duoquote/agg_test/node_modules/@cetusprotocol/aggregator-sdk/dist/index.js:5677:11)
    at AggregatorClient8.<anonymous> (file:///home/duoquote/agg_test/node_modules/@cetusprotocol/aggregator-sdk/dist/index.js:6303:32)
    at Generator.next (<anonymous>)
    at fulfilled (file:///home/duoquote/agg_test/node_modules/@cetusprotocol/aggregator-sdk/dist/index.js:57:24)
    at process.processTicksAndRejections (node:internal/process/task_queues:105:5) {
  [errors]: [
    'I', 'n', 's', 'u', 'f', 'f', 'i', 'c', 'i', 'e', 'n', 't',
    ' ', 'b', 'a', 'l', 'a', 'n', 'c', 'e', ' ', 'w', 'h', 'e',
    'n', ' ', 'b', 'u', 'i', 'l', 'd', ' ', 'm', 'e', 'r', 'g',
    'e', ' ', 'c', 'o', 'i', 'n', ',', ' ', 'c', 'o', 'i', 'n',
    'T', 'y', 'p', 'e', ':', ' ', '0', 'x', 'd', 'e', 'e', 'b',
    '7', 'a', '4', '6', '6', '2', 'e', 'e', 'c', '9', 'f', '2',
    'f', '3', 'd', 'e', 'f', '0', '3', 'f', 'b', '9', '3', '7',
    'a', '6', '6', '3', 'd', 'd', 'd', 'a', 'a', '2', 'e', '2',
    '1', '5', 'b', '8',
    ... 32 more items
  ]
}

```